### PR TITLE
[feat/#71] 회원탈퇴 api 구현

### DIFF
--- a/app/src/main/java/umc/link/zip/data/dto/mypage/response/WithdrawalResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/mypage/response/WithdrawalResponse.kt
@@ -1,0 +1,12 @@
+package umc.link.zip.data.dto.mypage.response
+
+import umc.link.zip.domain.model.mypage.WithdrawalModel
+
+
+data class WithdrawalResponse(
+    var isDeleted: Boolean
+){
+    fun toModel() = WithdrawalModel (
+        isDeleted = isDeleted
+    )
+}

--- a/app/src/main/java/umc/link/zip/data/repositoryImpl/MypageRepositoryImpl.kt
+++ b/app/src/main/java/umc/link/zip/data/repositoryImpl/MypageRepositoryImpl.kt
@@ -7,10 +7,12 @@ import umc.link.zip.data.dto.mypage.response.EditNicknmResponse
 import umc.link.zip.data.dto.mypage.response.GetNoticeDetailResponse
 import umc.link.zip.data.dto.mypage.response.GetNoticeResponse
 import umc.link.zip.data.dto.mypage.response.UserInfoResponse
+import umc.link.zip.data.dto.mypage.response.WithdrawalResponse
 import umc.link.zip.data.service.MypageService
 import umc.link.zip.domain.model.mypage.CheckNicknmModel
 import umc.link.zip.domain.model.mypage.EditNicknmModel
 import umc.link.zip.domain.model.mypage.UserInfoModel
+import umc.link.zip.domain.model.mypage.WithdrawalModel
 import umc.link.zip.domain.model.notice.Notice
 import umc.link.zip.domain.model.notice.NoticeList
 import umc.link.zip.domain.repository.MypageRepository
@@ -35,5 +37,8 @@ class MypageRepositoryImpl @Inject constructor(
     }
     override suspend fun editNicknm(nickname : EditNicknmRequest): NetworkResult<EditNicknmModel> {
         return handleApi({mypageService.editNickname(nickname)}) {response: BaseResponse<EditNicknmResponse> -> response.result.toModel()} // mapper를 통해 api 결과를 TestModel로 매핑
+    }
+    override suspend fun deleteUser(): NetworkResult<WithdrawalModel> {
+        return handleApi({mypageService.deleteUser()}) {response: BaseResponse<WithdrawalResponse> -> response.result.toModel()}
     }
 }

--- a/app/src/main/java/umc/link/zip/data/service/MypageService.kt
+++ b/app/src/main/java/umc/link/zip/data/service/MypageService.kt
@@ -2,6 +2,7 @@ package umc.link.zip.data.service
 
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.Path
@@ -13,6 +14,7 @@ import umc.link.zip.data.dto.mypage.response.EditNicknmResponse
 import umc.link.zip.data.dto.mypage.response.GetNoticeDetailResponse
 import umc.link.zip.data.dto.mypage.response.GetNoticeResponse
 import umc.link.zip.data.dto.mypage.response.UserInfoResponse
+import umc.link.zip.data.dto.mypage.response.WithdrawalResponse
 
 interface MypageService {
     @GET("/user")
@@ -29,4 +31,7 @@ interface MypageService {
 
     @PATCH("/user")
     suspend fun editNickname(@Body request: EditNicknmRequest) : Response<BaseResponse<EditNicknmResponse>>
+
+    @DELETE("/user/delete")
+    suspend fun deleteUser() : Response<BaseResponse<WithdrawalResponse>>
 }

--- a/app/src/main/java/umc/link/zip/domain/model/mypage/WithdrawalModel.kt
+++ b/app/src/main/java/umc/link/zip/domain/model/mypage/WithdrawalModel.kt
@@ -1,0 +1,5 @@
+package umc.link.zip.domain.model.mypage
+
+data class WithdrawalModel (
+    val isDeleted : Boolean
+)

--- a/app/src/main/java/umc/link/zip/domain/repository/MypageRepository.kt
+++ b/app/src/main/java/umc/link/zip/domain/repository/MypageRepository.kt
@@ -4,6 +4,7 @@ import umc.link.zip.data.dto.mypage.request.EditNicknmRequest
 import umc.link.zip.domain.model.mypage.CheckNicknmModel
 import umc.link.zip.domain.model.mypage.EditNicknmModel
 import umc.link.zip.domain.model.mypage.UserInfoModel
+import umc.link.zip.domain.model.mypage.WithdrawalModel
 import umc.link.zip.domain.model.notice.Notice
 import umc.link.zip.domain.model.notice.NoticeList
 import umc.link.zip.util.network.NetworkResult
@@ -14,4 +15,5 @@ interface MypageRepository {
     suspend fun getNotice(): NetworkResult<NoticeList>
     suspend fun getNoticeDetail(noticeId: Int): NetworkResult<Notice>
     suspend fun editNicknm(request: EditNicknmRequest): NetworkResult<EditNicknmModel>
+    suspend fun deleteUser(): NetworkResult<WithdrawalModel>
 }

--- a/app/src/main/java/umc/link/zip/presentation/mypage/MypageWithdrawalFragment.kt
+++ b/app/src/main/java/umc/link/zip/presentation/mypage/MypageWithdrawalFragment.kt
@@ -1,23 +1,63 @@
 package umc.link.zip.presentation.mypage
 
+import android.content.Intent
+import android.util.Log
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import umc.link.zip.R
+import umc.link.zip.data.UserPreferences
 import umc.link.zip.databinding.FragmentMypageWithdrawalBinding
+import umc.link.zip.domain.model.mypage.CheckNicknmModel
+import umc.link.zip.domain.model.mypage.WithdrawalModel
+import umc.link.zip.presentation.SplashActivity
 import umc.link.zip.presentation.base.BaseFragment
+import umc.link.zip.util.extension.repeatOnStarted
+import umc.link.zip.util.network.UiState
 
 @AndroidEntryPoint
 class MypageWithdrawalFragment : BaseFragment<FragmentMypageWithdrawalBinding>(R.layout.fragment_mypage_withdrawal) {
 
     private val navigator by lazy { findNavController() }
+    private val viewModel: MypageWithdrawalViewModel by viewModels()
     override fun initObserver() {
-
+        repeatOnStarted {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    when (state) {
+                        UiState.Empty -> Log.d("DeleteUser", "Empty")
+                        is UiState.Error ->  // 에러 상태 처리
+                            Log.e("DeleteUser", "Error fetching data", state.error)
+                        UiState.Loading -> Log.d("DeleteUser", "Loading data")
+                        is UiState.Success ->
+                        {
+                            val data = state.data as WithdrawalModel
+                            if(data.isDeleted){
+                                Log.d("DeleteUser", "회원 삭제 성공")
+                                UserPreferences(requireContext()).deleteUserId()
+                                val splashIntent = Intent(requireContext(), SplashActivity::class.java)
+                                splashIntent.flags = Intent.FLAG_ACTIVITㅣY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                                startActivity(splashIntent)
+                                activity?.finish()
+                            }else{
+                                Log.d("DeleteUser", "삭제 실패")
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     override fun initView() {
-
         binding.ivMypageWithdrawalToolbarBack.setOnClickListener{
             navigator.navigateUp()
+        }
+
+        binding.clMypageWithdrawalBtn.setOnClickListener{
+            viewModel.deleteUser()
         }
     }
 

--- a/app/src/main/java/umc/link/zip/presentation/mypage/MypageWithdrawalViewModel.kt
+++ b/app/src/main/java/umc/link/zip/presentation/mypage/MypageWithdrawalViewModel.kt
@@ -1,0 +1,52 @@
+package umc.link.zip.presentation.mypage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import umc.link.zip.domain.model.mypage.WithdrawalModel
+import umc.link.zip.domain.model.notice.NoticeList
+import umc.link.zip.domain.repository.MypageRepository
+import umc.link.zip.util.network.NetworkResult
+import umc.link.zip.util.network.UiState
+import umc.link.zip.util.network.onError
+import umc.link.zip.util.network.onException
+import umc.link.zip.util.network.onFail
+import javax.inject.Inject
+
+@HiltViewModel
+class MypageWithdrawalViewModel @Inject constructor(
+    private val repository: MypageRepository // 후에 api 연결 시 사용
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<UiState<WithdrawalModel>>(UiState.Loading)
+    val uiState: StateFlow<UiState<WithdrawalModel>> = _uiState.asStateFlow()
+
+    fun deleteUser() {
+        viewModelScope.launch {
+            repository.deleteUser().apply {
+                when (this) {
+                    is NetworkResult.Success -> {
+                        _uiState.value = UiState.Loading  // 상태를 초기화 (동일한 데이터가 와도 방출될 수 있도록)
+                        _uiState.value = UiState.Success(this.data)
+                    }
+                    is NetworkResult.Error -> {
+                        _uiState.value = UiState.Error(this.exception)
+                    }
+                    is NetworkResult.Fail -> {
+                        _uiState.value = UiState.Error(Throwable("Failed to load data"))
+                    }
+                }
+            }.onError {
+                _uiState.value = UiState.Error(it)
+            }.onException {
+                _uiState.value = UiState.Error(it)
+            }.onFail {
+                _uiState.value = UiState.Error(Throwable("Failed to load data"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #71

## 📌 개요
- 회원탈퇴 api 구현 완료

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/95f6ab82-e999-4513-b108-bae567c6c6fb)
버튼 클릭시 스플래시 화면 돌아갑니다.
이후 로그인 하면 회원가입 절차가 뜹니다.


## 👀 기타 더 이야기해볼 점
