### PR TITLE
[Feat/#67] 토큰 갱신 API

### DIFF
--- a/app/src/main/java/umc/link/zip/data/AuthInterceptor.kt
+++ b/app/src/main/java/umc/link/zip/data/AuthInterceptor.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class AuthInterceptor(private val context: Context) : Interceptor {
+class AuthInterceptor(
+    private val context: Context
+    ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
         // login API 요청인 경우, 인증 헤더를 추가하지 않음
-        if (originalRequest.url.encodedPath.endsWith("/user/token/test")) {
+        if (originalRequest.url.encodedPath.endsWith("/user/login") or
+            originalRequest.url.encodedPath.endsWith("/user/refresh")) {
             return chain.proceed(originalRequest)
         }
 

--- a/app/src/main/java/umc/link/zip/data/UserPreferences.kt
+++ b/app/src/main/java/umc/link/zip/data/UserPreferences.kt
@@ -2,6 +2,7 @@ package umc.link.zip.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import umc.link.zip.domain.model.login.TokenModel
 
 class UserPreferences(context: Context) {
 
@@ -10,11 +11,35 @@ class UserPreferences(context: Context) {
 
     companion object {
         private const val USER_ID_KEY = "user_id"
+        private const val USER_ID_KEY_EXPIRES = "user_id_expires"
+        private const val USER_ID_KEY_REFRESH = "user_id_refresh"
+        private const val USER_ID_KEY_REFRESH_EXPIRES = "user_id_refresh_expires"
     }
 
-    fun saveUserId(userId: String) {
+    fun saveAccessToken(accessToken: String) {
         with(sharedPreferences.edit()) {
-            putString(USER_ID_KEY, userId)
+            putString(USER_ID_KEY, accessToken)
+            apply()
+        }
+    }
+
+    fun saveAccessTokenExpires(accessTokenExpires: String) {
+        with(sharedPreferences.edit()) {
+            putString(USER_ID_KEY_EXPIRES, accessTokenExpires)
+            apply()
+        }
+    }
+
+    fun saveRefreshToken(refreshToken: String) {
+        with(sharedPreferences.edit()) {
+            putString(USER_ID_KEY_REFRESH, refreshToken)
+            apply()
+        }
+    }
+
+    fun saveRefreshTokenExpires(refreshTokenExpires: String) {
+        with(sharedPreferences.edit()) {
+            putString(USER_ID_KEY_REFRESH_EXPIRES, refreshTokenExpires)
             apply()
         }
     }
@@ -23,9 +48,20 @@ class UserPreferences(context: Context) {
         return sharedPreferences.getString(USER_ID_KEY, null)
     }
 
+    fun getUserIdExpires(): String? {
+        return sharedPreferences.getString(USER_ID_KEY_EXPIRES, null)
+    }
+
+    fun getUserIdRefresh(): String? {
+        return sharedPreferences.getString(USER_ID_KEY_REFRESH, null)
+    }
+
     fun deleteUserId() {
         with(sharedPreferences.edit()) {
             remove(USER_ID_KEY)
+            remove(USER_ID_KEY_EXPIRES)
+            remove(USER_ID_KEY_REFRESH)
+            remove(USER_ID_KEY_REFRESH_EXPIRES)
             apply()
         }
     }

--- a/app/src/main/java/umc/link/zip/data/dto/TokenAuthenticator.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/TokenAuthenticator.kt
@@ -13,13 +13,13 @@ import umc.link.zip.data.service.LoginService
 import javax.inject.Inject
 
 class TokenAuthenticator @Inject constructor(
-    private val userPreferences: UserPreferences,
-    private val loginService: LoginService,
+    private val loginService: dagger.Lazy<LoginService>,
     private val context: Context
 ) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
         synchronized(this) {
+            val loginService = loginService.get()
             // 이미 갱신을 시도한 경우, 무한 루프를 방지하기 위해 null을 반환
             if (responseCount(response) >= 3) {
                 restartApp(context)
@@ -27,7 +27,7 @@ class TokenAuthenticator @Inject constructor(
             }
 
             val currentTime = System.currentTimeMillis() / 1000 // 초 단위로 변환
-            val accessTokenExpires = userPreferences.getUserIdExpires()?.toLongOrNull()
+            val accessTokenExpires = UserPreferences(context).getUserIdExpires()?.toLongOrNull()
 
             // 만료 시간이 현재 시간을 초과하면 토큰 갱신 필요 없음
             if (accessTokenExpires != null && currentTime < accessTokenExpires) {
@@ -37,7 +37,7 @@ class TokenAuthenticator @Inject constructor(
 
             // 토큰 갱신을 동기적으로 처리
             val newTokenResponse = runBlocking {
-                val refreshToken = userPreferences.getUserIdRefresh()
+                val refreshToken = UserPreferences(context).getUserIdRefresh()
                 if(refreshToken != null) {
                     loginService.refresh(RefreshRequest(refreshToken))
                 } else {
@@ -48,11 +48,11 @@ class TokenAuthenticator @Inject constructor(
 
             if (newTokenResponse?.isSuccessful == true) {
                 val newAccessToken = newTokenResponse.body()?.result?.accessToken
-                val newAccessTokenExpires = newTokenResponse.body()?.result?.accessTokenExpires
+                val newAccessTokenExpires = newTokenResponse.body()?.result?.accessTokenExpiresAt
 
                 // 새로 받은 토큰을 저장
-                userPreferences.saveAccessToken(newAccessToken ?: "")
-                userPreferences.saveAccessTokenExpires(newAccessTokenExpires ?: "")
+                UserPreferences(context).saveAccessToken(newAccessToken ?: "")
+                UserPreferences(context).saveAccessTokenExpires(newAccessTokenExpires ?: "")
 
                 // 새로운 토큰으로 원래 요청을 다시 만듦
                 return response.request.newBuilder()
@@ -80,7 +80,7 @@ class TokenAuthenticator @Inject constructor(
         val packageManager = context.packageManager
         val intent = packageManager.getLaunchIntentForPackage(context.packageName)
         val mainIntent = Intent.makeRestartActivityTask(intent?.component)
-        userPreferences.deleteUserId()
+        UserPreferences(context).deleteUserId()
         context.startActivity(mainIntent)
         Runtime.getRuntime().exit(0)
     }

--- a/app/src/main/java/umc/link/zip/data/dto/TokenAuthenticator.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/TokenAuthenticator.kt
@@ -1,0 +1,87 @@
+package umc.link.zip.data.dto
+
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import umc.link.zip.data.UserPreferences
+import umc.link.zip.data.dto.request.RefreshRequest
+import umc.link.zip.data.service.LoginService
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    private val userPreferences: UserPreferences,
+    private val loginService: LoginService,
+    private val context: Context
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        synchronized(this) {
+            // 이미 갱신을 시도한 경우, 무한 루프를 방지하기 위해 null을 반환
+            if (responseCount(response) >= 3) {
+                restartApp(context)
+                return null
+            }
+
+            val currentTime = System.currentTimeMillis() / 1000 // 초 단위로 변환
+            val accessTokenExpires = userPreferences.getUserIdExpires()?.toLongOrNull()
+
+            // 만료 시간이 현재 시간을 초과하면 토큰 갱신 필요 없음
+            if (accessTokenExpires != null && currentTime < accessTokenExpires) {
+                restartApp(context)
+                return null
+            }
+
+            // 토큰 갱신을 동기적으로 처리
+            val newTokenResponse = runBlocking {
+                val refreshToken = userPreferences.getUserIdRefresh()
+                if(refreshToken != null) {
+                    loginService.refresh(RefreshRequest(refreshToken))
+                } else {
+                    restartApp(context)
+                    null
+                }
+            }
+
+            if (newTokenResponse?.isSuccessful == true) {
+                val newAccessToken = newTokenResponse.body()?.result?.accessToken
+                val newAccessTokenExpires = newTokenResponse.body()?.result?.accessTokenExpires
+
+                // 새로 받은 토큰을 저장
+                userPreferences.saveAccessToken(newAccessToken ?: "")
+                userPreferences.saveAccessTokenExpires(newAccessTokenExpires ?: "")
+
+                // 새로운 토큰으로 원래 요청을 다시 만듦
+                return response.request.newBuilder()
+                    .header("Authorization", "Bearer $newAccessToken")
+                    .build()
+            } else {
+                restartApp(context)
+                return null
+            }
+        }
+    }
+
+    // 응답 횟수 체크
+    private fun responseCount(response: Response): Int {
+        var result = 1
+        var priorResponse = response.priorResponse
+        while (priorResponse != null) {
+            result++
+            priorResponse = priorResponse.priorResponse
+        }
+        return result
+    }
+
+    private fun restartApp(context: Context) {
+        val packageManager = context.packageManager
+        val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+        val mainIntent = Intent.makeRestartActivityTask(intent?.component)
+        userPreferences.deleteUserId()
+        context.startActivity(mainIntent)
+        Runtime.getRuntime().exit(0)
+    }
+}

--- a/app/src/main/java/umc/link/zip/data/dto/request/LoginRequest.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/request/LoginRequest.kt
@@ -2,7 +2,7 @@ package umc.link.zip.data.dto.request
 
 data class LoginRequest(
     val accessToken: String,
-    val accessTokenExpires: String,
+    val accessTokenExpiresAt: String,
     val refreshToken: String,
-    val refreshTokenExpires: String
+    val refreshTokenExpiresAt: String
 )

--- a/app/src/main/java/umc/link/zip/data/dto/request/RefreshRequest.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/request/RefreshRequest.kt
@@ -1,0 +1,5 @@
+package umc.link.zip.data.dto.request
+
+data class RefreshRequest(
+    val refreshToken: String
+)

--- a/app/src/main/java/umc/link/zip/data/dto/response/LoginResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/response/LoginResponse.kt
@@ -16,15 +16,15 @@ data class LoginResponse(
 
     data class TokenResponse (
         val accessToken: String,
-        val accessTokenExpires: String,
+        val accessTokenExpiresAt: String,
         val refreshToken: String,
-        val refreshTokenExpires: String,
+        val refreshTokenExpiresAt: String,
     ) {
         fun toTokenModel() = TokenModel(
             accessToken = this.accessToken,
-            accessTokenExpires = this.accessTokenExpires,
+            accessTokenExpiresAt = this.accessTokenExpiresAt,
             refreshToken = this.refreshToken,
-            refreshTokenExpires = this.refreshTokenExpires
+            refreshTokenExpiresAt = this.refreshTokenExpiresAt
         )
     }
 }

--- a/app/src/main/java/umc/link/zip/data/dto/response/LoginResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/response/LoginResponse.kt
@@ -16,11 +16,15 @@ data class LoginResponse(
 
     data class TokenResponse (
         val accessToken: String,
-        val accessTokenExpiresIn: String,
+        val accessTokenExpires: String,
+        val refreshToken: String,
+        val refreshTokenExpires: String,
     ) {
         fun toTokenModel() = TokenModel(
             accessToken = this.accessToken,
-            accessTokenExpiresIn = this.accessTokenExpiresIn
+            accessTokenExpires = this.accessTokenExpires,
+            refreshToken = this.refreshToken,
+            refreshTokenExpires = this.refreshTokenExpires
         )
     }
 }

--- a/app/src/main/java/umc/link/zip/data/dto/response/RefreshResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/response/RefreshResponse.kt
@@ -4,10 +4,10 @@ import umc.link.zip.domain.model.login.RefreshModel
 
 data class RefreshResponse(
     val accessToken: String,
-    val accessTokenExpires: String
+    val accessTokenExpiresAt: String
 ) {
     fun toModel() = RefreshModel(
         accessToken = this.accessToken,
-        accessTokenExpires = this.accessTokenExpires
+        accessTokenExpiresAt = this.accessTokenExpiresAt
     )
 }

--- a/app/src/main/java/umc/link/zip/data/dto/response/RefreshResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/response/RefreshResponse.kt
@@ -1,0 +1,13 @@
+package umc.link.zip.data.dto.response
+
+import umc.link.zip.domain.model.login.RefreshModel
+
+data class RefreshResponse(
+    val accessToken: String,
+    val accessTokenExpires: String
+) {
+    fun toModel() = RefreshModel(
+        accessToken = this.accessToken,
+        accessTokenExpires = this.accessTokenExpires
+    )
+}

--- a/app/src/main/java/umc/link/zip/data/dto/response/SignupResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/response/SignupResponse.kt
@@ -4,14 +4,14 @@ import umc.link.zip.domain.model.login.TokenModel
 
 data class SignupResponse(
     val accessToken: String,
-    val accessTokenExpires: String,
+    val accessTokenExpiresAt: String,
     val refreshToken: String,
-    val refreshTokenExpires: String,
+    val refreshTokenExpiresAt: String,
 ) {
     fun toModel() = TokenModel(
         accessToken = this.accessToken,
-        accessTokenExpires = this.accessTokenExpires,
+        accessTokenExpiresAt = this.accessTokenExpiresAt,
         refreshToken = this.refreshToken,
-        refreshTokenExpires = this.refreshTokenExpires
+        refreshTokenExpiresAt = this.refreshTokenExpiresAt
     )
 }

--- a/app/src/main/java/umc/link/zip/data/dto/response/SignupResponse.kt
+++ b/app/src/main/java/umc/link/zip/data/dto/response/SignupResponse.kt
@@ -1,11 +1,17 @@
 package umc.link.zip.data.dto.response
 
-import umc.link.zip.domain.model.login.SignupModel
+import umc.link.zip.domain.model.login.TokenModel
 
 data class SignupResponse(
-    val accessToken: String
+    val accessToken: String,
+    val accessTokenExpires: String,
+    val refreshToken: String,
+    val refreshTokenExpires: String,
 ) {
-    fun toModel() = SignupModel(
-        accessToken = this.accessToken
+    fun toModel() = TokenModel(
+        accessToken = this.accessToken,
+        accessTokenExpires = this.accessTokenExpires,
+        refreshToken = this.refreshToken,
+        refreshTokenExpires = this.refreshTokenExpires
     )
 }

--- a/app/src/main/java/umc/link/zip/data/repositoryImpl/LoginRepositoryImpl.kt
+++ b/app/src/main/java/umc/link/zip/data/repositoryImpl/LoginRepositoryImpl.kt
@@ -1,21 +1,23 @@
 package umc.link.zip.data.repositoryImpl
 
-import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.awaitResponse
 import umc.link.zip.data.dto.BaseResponse
 import umc.link.zip.data.dto.request.LoginRequest
-import umc.link.zip.data.dto.response.JwtResponse
+import umc.link.zip.data.dto.request.RefreshRequest
 import umc.link.zip.data.dto.request.SignupRequest
+import umc.link.zip.data.dto.response.JwtResponse
 import umc.link.zip.data.dto.response.LoginResponse
 import umc.link.zip.data.dto.response.NameCheckResponse
+import umc.link.zip.data.dto.response.RefreshResponse
 import umc.link.zip.data.dto.response.SignupResponse
 import umc.link.zip.data.service.LoginService
 import umc.link.zip.domain.model.login.JwtModel
 import umc.link.zip.domain.model.login.LoginModel
 import umc.link.zip.domain.model.login.NameCheckModel
-import umc.link.zip.domain.model.login.SignupModel
+import umc.link.zip.domain.model.login.RefreshModel
+import umc.link.zip.domain.model.login.TokenModel
 import umc.link.zip.domain.repository.LoginRepository
 import umc.link.zip.util.network.NetworkResult
 import umc.link.zip.util.network.handleApi
@@ -44,7 +46,7 @@ class LoginRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun signup(request: SignupRequest): NetworkResult<SignupModel> {
+    override suspend fun signup(request: SignupRequest): NetworkResult<TokenModel> {
         return handleApi({loginService.signup(request)}) {response: BaseResponse<SignupResponse> ->
             response.result.toModel()
         }
@@ -64,4 +66,9 @@ class LoginRepositoryImpl @Inject constructor(
         }
     }
 
+    /*override suspend fun refresh(request: RefreshRequest): NetworkResult<RefreshModel> {
+        return handleApi({loginService.refresh(request)}) {response: BaseResponse<RefreshResponse> ->
+            response.result.toModel()
+        }
+    }*/
 }

--- a/app/src/main/java/umc/link/zip/data/service/LoginService.kt
+++ b/app/src/main/java/umc/link/zip/data/service/LoginService.kt
@@ -9,9 +9,11 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 import umc.link.zip.data.dto.BaseResponse
 import umc.link.zip.data.dto.request.LoginRequest
+import umc.link.zip.data.dto.request.RefreshRequest
 import umc.link.zip.data.dto.response.JwtResponse
 import umc.link.zip.data.dto.request.SignupRequest
 import umc.link.zip.data.dto.response.NameCheckResponse
+import umc.link.zip.data.dto.response.RefreshResponse
 import umc.link.zip.data.dto.response.SignupResponse
 
 interface LoginService {
@@ -27,6 +29,6 @@ interface LoginService {
     @POST("/user")
     suspend fun signup(@Body request: SignupRequest): Response<BaseResponse<SignupResponse>>
 
-    @POST("/user/token/test")
-    fun login(): Call<BaseResponse<LoginResponse>>
+    @POST("/user/refresh")
+    suspend fun refresh(@Body request: RefreshRequest): Response<BaseResponse<RefreshResponse>>
 }

--- a/app/src/main/java/umc/link/zip/di/NetworkModule.kt
+++ b/app/src/main/java/umc/link/zip/di/NetworkModule.kt
@@ -14,6 +14,9 @@ import retrofit2.converter.gson.GsonConverterFactory
 import umc.link.zip.LinkZipApplication
 import umc.link.zip.R
 import umc.link.zip.data.AuthInterceptor
+import umc.link.zip.data.UserPreferences
+import umc.link.zip.data.dto.TokenAuthenticator
+import umc.link.zip.data.service.LoginService
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -45,8 +48,19 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    fun providesTokenAuthenticator(
+        userPreferences: UserPreferences,
+        loginService: LoginService,
+        context: Context
+    ): TokenAuthenticator {
+        return TokenAuthenticator(userPreferences, loginService, context)
+    }
+
+    @Provides
+    @Singleton
     fun providesOkHttpClient(
-        authInterceptor: AuthInterceptor
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator
     ): OkHttpClient {
         val interceptor = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
@@ -54,6 +68,7 @@ object NetworkModule {
         return OkHttpClient.Builder().apply {
             addInterceptor(authInterceptor)
             addInterceptor(interceptor)
+            authenticator(tokenAuthenticator)
             connectTimeout(5, TimeUnit.SECONDS)
             readTimeout(5, TimeUnit.SECONDS)
             writeTimeout(5, TimeUnit.SECONDS)

--- a/app/src/main/java/umc/link/zip/di/NetworkModule.kt
+++ b/app/src/main/java/umc/link/zip/di/NetworkModule.kt
@@ -14,7 +14,6 @@ import retrofit2.converter.gson.GsonConverterFactory
 import umc.link.zip.LinkZipApplication
 import umc.link.zip.R
 import umc.link.zip.data.AuthInterceptor
-import umc.link.zip.data.UserPreferences
 import umc.link.zip.data.dto.TokenAuthenticator
 import umc.link.zip.data.service.LoginService
 import java.util.concurrent.TimeUnit
@@ -49,11 +48,10 @@ object NetworkModule {
     @Provides
     @Singleton
     fun providesTokenAuthenticator(
-        userPreferences: UserPreferences,
-        loginService: LoginService,
+        loginService: dagger.Lazy<LoginService>,
         context: Context
     ): TokenAuthenticator {
-        return TokenAuthenticator(userPreferences, loginService, context)
+        return TokenAuthenticator(loginService, context)
     }
 
     @Provides

--- a/app/src/main/java/umc/link/zip/domain/model/login/RefreshModel.kt
+++ b/app/src/main/java/umc/link/zip/domain/model/login/RefreshModel.kt
@@ -2,5 +2,5 @@ package umc.link.zip.domain.model.login
 
 data class RefreshModel(
     val accessToken: String,
-    val accessTokenExpires: String
+    val accessTokenExpiresAt: String
 )

--- a/app/src/main/java/umc/link/zip/domain/model/login/RefreshModel.kt
+++ b/app/src/main/java/umc/link/zip/domain/model/login/RefreshModel.kt
@@ -1,0 +1,6 @@
+package umc.link.zip.domain.model.login
+
+data class RefreshModel(
+    val accessToken: String,
+    val accessTokenExpires: String
+)

--- a/app/src/main/java/umc/link/zip/domain/model/login/SignupModel.kt
+++ b/app/src/main/java/umc/link/zip/domain/model/login/SignupModel.kt
@@ -1,5 +1,0 @@
-package umc.link.zip.domain.model.login
-
-data class SignupModel(
-    val accessToken: String
-)

--- a/app/src/main/java/umc/link/zip/domain/model/login/TokenModel.kt
+++ b/app/src/main/java/umc/link/zip/domain/model/login/TokenModel.kt
@@ -2,5 +2,7 @@ package umc.link.zip.domain.model.login
 
 data class TokenModel(
     val accessToken: String,
-    val accessTokenExpiresIn: String,
+    val accessTokenExpires: String,
+    val refreshToken: String,
+    val refreshTokenExpires: String,
 )

--- a/app/src/main/java/umc/link/zip/domain/model/login/TokenModel.kt
+++ b/app/src/main/java/umc/link/zip/domain/model/login/TokenModel.kt
@@ -2,7 +2,7 @@ package umc.link.zip.domain.model.login
 
 data class TokenModel(
     val accessToken: String,
-    val accessTokenExpires: String,
+    val accessTokenExpiresAt: String,
     val refreshToken: String,
-    val refreshTokenExpires: String,
+    val refreshTokenExpiresAt: String,
 )

--- a/app/src/main/java/umc/link/zip/domain/repository/LoginRepository.kt
+++ b/app/src/main/java/umc/link/zip/domain/repository/LoginRepository.kt
@@ -1,12 +1,10 @@
 package umc.link.zip.domain.repository
 
 import umc.link.zip.data.dto.request.LoginRequest
-import umc.link.zip.data.dto.request.RefreshRequest
 import umc.link.zip.data.dto.request.SignupRequest
 import umc.link.zip.domain.model.login.JwtModel
 import umc.link.zip.domain.model.login.LoginModel
 import umc.link.zip.domain.model.login.NameCheckModel
-import umc.link.zip.domain.model.login.RefreshModel
 import umc.link.zip.domain.model.login.TokenModel
 import umc.link.zip.util.network.NetworkResult
 
@@ -18,6 +16,4 @@ interface LoginRepository {
     suspend fun nameCheck(nickname: String): NetworkResult<NameCheckModel>
 
     suspend fun signup(request: SignupRequest): NetworkResult<TokenModel>
-
-   /* suspend fun refresh(request: RefreshRequest): NetworkResult<RefreshModel>*/
 }

--- a/app/src/main/java/umc/link/zip/domain/repository/LoginRepository.kt
+++ b/app/src/main/java/umc/link/zip/domain/repository/LoginRepository.kt
@@ -1,11 +1,13 @@
 package umc.link.zip.domain.repository
 
 import umc.link.zip.data.dto.request.LoginRequest
-import umc.link.zip.domain.model.login.JwtModel
+import umc.link.zip.data.dto.request.RefreshRequest
 import umc.link.zip.data.dto.request.SignupRequest
+import umc.link.zip.domain.model.login.JwtModel
 import umc.link.zip.domain.model.login.LoginModel
 import umc.link.zip.domain.model.login.NameCheckModel
-import umc.link.zip.domain.model.login.SignupModel
+import umc.link.zip.domain.model.login.RefreshModel
+import umc.link.zip.domain.model.login.TokenModel
 import umc.link.zip.util.network.NetworkResult
 
 interface LoginRepository {
@@ -15,5 +17,7 @@ interface LoginRepository {
 
     suspend fun nameCheck(nickname: String): NetworkResult<NameCheckModel>
 
-    suspend fun signup(request: SignupRequest): NetworkResult<SignupModel>
+    suspend fun signup(request: SignupRequest): NetworkResult<TokenModel>
+
+   /* suspend fun refresh(request: RefreshRequest): NetworkResult<RefreshModel>*/
 }

--- a/app/src/main/java/umc/link/zip/presentation/SplashActivity.kt
+++ b/app/src/main/java/umc/link/zip/presentation/SplashActivity.kt
@@ -36,9 +36,6 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_spl
                 }
                 is NetworkResult.Fail -> {
                     Log.d("login", "Jwt 확인 실패 : ${result.statusCode}")
-                    if(result.message == "Unauthorized") {
-                        navigateToLoginActivity()
-                    }
                 }
                 is NetworkResult.Success -> {
                     Log.d("login", "Jwt 확인 성공")

--- a/app/src/main/java/umc/link/zip/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/umc/link/zip/presentation/login/LoginActivity.kt
@@ -46,7 +46,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 
                 is NetworkResult.Success -> {
                     if(result.data.isExists) {
-                        Log.d("login", "기존 회원 : ${result.data.tokenResponse!!.accessToken}")
+                        Log.d("login", "기존 회원 : ${result.data.tokenResponse!!}")
                         saveToken(result.data.tokenResponse)
                         startActivity(Intent(this, MainActivity::class.java))
                         finish()
@@ -66,9 +66,9 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 
     private fun saveToken(token: TokenModel) {
         UserPreferences(this).saveAccessToken(token.accessToken)
-        UserPreferences(this).saveAccessTokenExpires(token.accessTokenExpires)
+        UserPreferences(this).saveAccessTokenExpires(token.accessTokenExpiresAt)
         UserPreferences(this).saveRefreshToken(token.refreshToken)
-        UserPreferences(this).saveRefreshTokenExpires(token.refreshTokenExpires)
+        UserPreferences(this).saveRefreshTokenExpires(token.refreshTokenExpiresAt)
     }
 
     // 카카오 로그인
@@ -90,9 +90,9 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
     private fun sendLoginRequest(token: OAuthToken) {
         val request = LoginRequest(
             accessToken = token.accessToken,
-            accessTokenExpires = token.accessTokenExpiresAt.toString(),
+            accessTokenExpiresAt = token.accessTokenExpiresAt.toString(),
             refreshToken = token.refreshToken,
-            refreshTokenExpires = token.refreshTokenExpiresAt.toString()
+            refreshTokenExpiresAt = token.refreshTokenExpiresAt.toString()
         )
 
         viewModel.login(request)

--- a/app/src/main/java/umc/link/zip/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/umc/link/zip/presentation/login/LoginActivity.kt
@@ -18,6 +18,7 @@ import umc.link.zip.R
 import umc.link.zip.data.UserPreferences
 import umc.link.zip.data.dto.request.LoginRequest
 import umc.link.zip.databinding.ActivityLoginBinding
+import umc.link.zip.domain.model.login.TokenModel
 import umc.link.zip.presentation.MainActivity
 import umc.link.zip.presentation.base.BaseActivity
 import umc.link.zip.util.network.NetworkResult
@@ -46,8 +47,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
                 is NetworkResult.Success -> {
                     if(result.data.isExists) {
                         Log.d("login", "기존 회원 : ${result.data.tokenResponse!!.accessToken}")
-                        Log.d("login", "기존 회원 : ${result.data.tokenResponse.accessTokenExpiresIn}")
-                        saveAccessToken(result.data.tokenResponse.accessToken)
+                        saveToken(result.data.tokenResponse)
                         startActivity(Intent(this, MainActivity::class.java))
                         finish()
                     } else {
@@ -64,8 +64,11 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
         }
     }
 
-    private fun saveAccessToken(accessToken: String) {
-        UserPreferences(this).saveUserId(accessToken)
+    private fun saveToken(token: TokenModel) {
+        UserPreferences(this).saveAccessToken(token.accessToken)
+        UserPreferences(this).saveAccessTokenExpires(token.accessTokenExpires)
+        UserPreferences(this).saveRefreshToken(token.refreshToken)
+        UserPreferences(this).saveRefreshTokenExpires(token.refreshTokenExpires)
     }
 
     // 카카오 로그인

--- a/app/src/main/java/umc/link/zip/presentation/login/ProfilesetFragment.kt
+++ b/app/src/main/java/umc/link/zip/presentation/login/ProfilesetFragment.kt
@@ -69,9 +69,9 @@ class ProfilesetFragment : BaseFragment<FragmentProfilesetBinding>(R.layout.frag
 
     private fun saveToken(token: TokenModel) {
         UserPreferences(requireContext()).saveAccessToken(token.accessToken)
-        UserPreferences(requireContext()).saveAccessTokenExpires(token.accessTokenExpires)
+        UserPreferences(requireContext()).saveAccessTokenExpires(token.accessTokenExpiresAt)
         UserPreferences(requireContext()).saveRefreshToken(token.refreshToken)
-        UserPreferences(requireContext()).saveRefreshTokenExpires(token.refreshTokenExpires)
+        UserPreferences(requireContext()).saveRefreshTokenExpires(token.refreshTokenExpiresAt)
     }
 
     private fun setNameCheckObserver() {

--- a/app/src/main/java/umc/link/zip/presentation/login/ProfilesetFragment.kt
+++ b/app/src/main/java/umc/link/zip/presentation/login/ProfilesetFragment.kt
@@ -22,6 +22,7 @@ import umc.link.zip.R
 import umc.link.zip.data.UserPreferences
 import umc.link.zip.data.dto.request.SignupRequest
 import umc.link.zip.databinding.FragmentProfilesetBinding
+import umc.link.zip.domain.model.login.TokenModel
 import umc.link.zip.presentation.base.BaseFragment
 import umc.link.zip.util.extension.colorOf
 import umc.link.zip.util.extension.drawableOf
@@ -51,7 +52,7 @@ class ProfilesetFragment : BaseFragment<FragmentProfilesetBinding>(R.layout.frag
                 is NetworkResult.Error -> { Log.d("profileset", "profileset error : ${result.exception}") }
                 is NetworkResult.Fail -> { Log.d("profileset", "profileset fail : ${result.message}") }
                 is NetworkResult.Success -> {
-                    UserPreferences(requireContext()).saveUserId(result.data.accessToken)
+                    saveToken(result.data)
                     val fragment = ProfilesetCompletedFragment().apply {
                         arguments = Bundle().apply {
                             putString("nickname", binding.etProfilesetNickname.text.toString())
@@ -64,6 +65,13 @@ class ProfilesetFragment : BaseFragment<FragmentProfilesetBinding>(R.layout.frag
                 }
             }
         }
+    }
+
+    private fun saveToken(token: TokenModel) {
+        UserPreferences(requireContext()).saveAccessToken(token.accessToken)
+        UserPreferences(requireContext()).saveAccessTokenExpires(token.accessTokenExpires)
+        UserPreferences(requireContext()).saveRefreshToken(token.refreshToken)
+        UserPreferences(requireContext()).saveRefreshTokenExpires(token.refreshTokenExpires)
     }
 
     private fun setNameCheckObserver() {

--- a/app/src/main/java/umc/link/zip/presentation/login/ProfilesetViewModel.kt
+++ b/app/src/main/java/umc/link/zip/presentation/login/ProfilesetViewModel.kt
@@ -8,7 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import umc.link.zip.data.dto.request.SignupRequest
 import umc.link.zip.domain.model.login.NameCheckModel
-import umc.link.zip.domain.model.login.SignupModel
+import umc.link.zip.domain.model.login.TokenModel
 import umc.link.zip.domain.repository.LoginRepository
 import umc.link.zip.util.network.NetworkResult
 import javax.inject.Inject
@@ -21,8 +21,8 @@ class ProfilesetViewModel @Inject constructor(
     private val _nameCheckResult = MutableLiveData<NetworkResult<NameCheckModel>>()
     val nameCheckResult: LiveData<NetworkResult<NameCheckModel>> = _nameCheckResult
 
-    private val _signupResult = MutableLiveData<NetworkResult<SignupModel>>()
-    val signupResult: LiveData<NetworkResult<SignupModel>> = _signupResult
+    private val _signupResult = MutableLiveData<NetworkResult<TokenModel>>()
+    val signupResult: LiveData<NetworkResult<TokenModel>> = _signupResult
 
     fun nameCheck(nickname: String) {
         viewModelScope.launch {


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #67 

## 📌 개요
- 토큰 갱신 API 연결
- 로그인 응답형식 변경
- UserPreference에서 accessTokenExpires와 refreshToken도 저장

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
