### PR TITLE
[FIX/#106] 검색 페이지 링크 이동 오류 수정

### DIFF
--- a/app/src/main/java/umc/link/zip/presentation/home/search/SearchFragment.kt
+++ b/app/src/main/java/umc/link/zip/presentation/home/search/SearchFragment.kt
@@ -346,6 +346,11 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         )
     }
 
+    override fun onResume() {
+        super.onResume()
+        setSearchBefore(false)
+    }
+
     private fun fnCount(int: Int){
         binding.tvSearchResultCount.text = int.toString()
     }

--- a/app/src/main/java/umc/link/zip/presentation/home/search/SearchFragment.kt
+++ b/app/src/main/java/umc/link/zip/presentation/home/search/SearchFragment.kt
@@ -333,7 +333,7 @@ class SearchFragment : BaseFragment<FragmentSearchBinding>(R.layout.fragment_sea
         SearchResultRVA(
             onItemClicked = { link ->
                 if(link.link.tag == "text"){
-                    val action = HomeFragmentDirections.actionHomeFragmentToOpenTextFragment(link.link.id)
+                    val action = SearchFragmentDirections.actionSearchFragmentToOpenTextFragment(link.link.id)
                     navigator.navigate(action)
                 }else{
                     val action = SearchFragmentDirections.actionSearchFragmentToOpenLinkFragment(link.link.id)


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
Close #106

## 📌 개요
- text 링크 연결 코드 수정
- 링크 페이지 연결 후 뒤로가기 시 검색페이지 원상태로 안돌아오는 오류 수정

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
